### PR TITLE
docs: internal contributing-notes placeholder

### DIFF
--- a/.github/CONTRIBUTING-NOTES.md
+++ b/.github/CONTRIBUTING-NOTES.md
@@ -1,0 +1,3 @@
+# Contributing notes
+
+Internal placeholder. See README for the active investigation case structure.


### PR DESCRIPTION
Adds an internal placeholder under .github/. No behaviour change.